### PR TITLE
Contracts: add EIP20 token interfaces and initial VBT

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,3 @@
+node_modules
+contracts/Migrations.sol
+contracts/SafeMath.sol

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": "solium:recommended",
+  "plugins": [
+    "security"
+  ],
+  "rules": {
+    "imports-on-top": 0,
+    "variable-declarations": 0,
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "indentation": [
+      "error",
+      4
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 0.0.0
+
+- Contracts: add value token to constructor ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: inherit EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: import EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: setup repo and add ValueBrandedToken contract ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))

--- a/contracts/EIP20TokenInterface.sol
+++ b/contracts/EIP20TokenInterface.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+import "./EIP20TokenOptionalInterface.sol";
+import "./EIP20TokenRequiredInterface.sol";
+
+
+/**
+ *  @title EIP20 Token Interface.
+ *
+ *  @notice Provides EIP20 token interface.
+ */
+/* solium-disable-next-line no-empty-blocks */ 
+contract EIP20TokenInterface is EIP20TokenOptionalInterface, EIP20TokenRequiredInterface { }

--- a/contracts/EIP20TokenOptionalInterface.sol
+++ b/contracts/EIP20TokenOptionalInterface.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title EIP20 Token Optional Interface.
+ *
+ *  @notice Provides optional function signatures for EIP20 token interface.
+ */
+interface EIP20TokenOptionalInterface {
+
+    /** Public Functions */
+
+    function name() external view returns (string);
+    function symbol() external view returns (string);
+    function decimals() external view returns (uint8);
+}

--- a/contracts/EIP20TokenRequiredInterface.sol
+++ b/contracts/EIP20TokenRequiredInterface.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title EIP20 Token Required Interface.
+ *
+ *  @notice Provides required function signatures and
+ *          event declarations for EIP20 token interface.
+ */
+interface EIP20TokenRequiredInterface {
+
+    /* Events */
+
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+
+
+    /* Public Functions */
+
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address _owner) external view returns (uint256 balance);
+    function allowance(address _owner, address _spender) external view returns (uint256 remaining);
+    function transfer(address _to, uint256 _value) external returns (bool success);
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool success);
+    function approve(address _spender, uint256 _value) external returns (bool success);
+}

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
+
 
 // Copyright 2018 OpenST Ltd.
 //
@@ -13,7 +14,7 @@ pragma solidity ^0.4.23;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // ----------------------------------------------------------------------------
 // Common: SafeMath Library Implementation
 //
@@ -27,41 +28,71 @@ pragma solidity ^0.4.23;
 
 
 /**
-   @title SafeMath
-   @notice Implements SafeMath
-*/
+ * @title SafeMath
+ * @dev Math operations with safety checks that revert on error.
+ */
 library SafeMath {
 
+    /**
+     * @dev Multiplies two numbers, reverts on overflow.
+     */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-        uint256 c = a * b;
+        // Gas optimization: this is cheaper than requiring 'a' not being zero,
+        // but the benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+        if (a == 0) {
+            return 0;
+        }
 
-        assert(a == 0 || c / a == b);
+        uint256 c = a * b;
+        require(c / a == b);
 
         return c;
     }
 
-
+    /**
+     * @dev Integer division of two numbers truncating the quotient, reverts
+     *      on division by zero.
+     */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Solidity automatically throws when dividing by 0
+        // Solidity only automatically asserts when dividing by 0.
+        require(b > 0);
         uint256 c = a / b;
 
-        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+        // There is no case in which this doesn't hold
+        // assert(a == b * c + a % b);
+
         return c;
     }
 
-
+    /**
+     * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is
+     *      greater than minuend).
+     *
+     */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-        assert(b <= a);
+        require(b <= a);
+        uint256 c = a - b;
 
-        return a - b;
+        return c;
     }
 
-
+    /**
+     * @dev Adds two numbers, reverts on overflow.
+     */
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;
-
-        assert(c >= a);
+        require(c >= a);
 
         return c;
+    }
+
+    /**
+     * @dev Divides two numbers and returns the remainder,
+     *      (unsigned integer modulo) reverts when dividing by zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0);
+        return a % b;
     }
 }

--- a/contracts/ValueBrandedToken.sol
+++ b/contracts/ValueBrandedToken.sol
@@ -1,0 +1,202 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import "./SafeMath.sol";
+import "./EIP20TokenRequiredInterface.sol";
+
+
+/**
+ * @title Value Branded Token.
+ *
+ * @notice Supports staking value tokens for minting utility branded tokens
+ *         where the conversion rate from value token to utility branded token
+ *         is not 1:1.
+ */
+contract ValueBrandedToken is EIP20TokenRequiredInterface {
+
+    /* Usings */
+
+    using SafeMath for uint256;
+
+
+    /* Events */
+
+    event StakeRequested(/*...*/);
+
+    event StakeRequestAccepted(/*...*/);
+
+    event StakeRequestRejected(/*...*/);
+
+
+    /* Storage */
+
+    EIP20TokenRequiredInterface public valueToken;
+
+    mapping(address /* staker */ => uint256 /* value branded tokens */) public stakeRequests;
+
+    /* Constructor */
+
+    /**
+     * @dev Constructor requires:
+     *          - valueToken address is not null.
+     *
+     * @param _valueToken Address for tokens staked to mint utility branded tokens.
+     */
+    constructor(
+        EIP20TokenRequiredInterface _valueToken
+        // TODO: conversion-rate-related parameters
+    )
+        public
+    {
+        require(
+            _valueToken != address(0),
+            "ValueToken is null."
+        );
+
+        valueToken = _valueToken;
+    }
+
+
+    /* External Functions */
+
+    /**
+     * @notice Transfers value tokens from msg.sender to itself,
+     *         stores the amount of value branded tokens to mint if request is accepted,
+     *         and emits information required to stake value branded tokens
+     *         to mint utility branded tokens.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function requestStake(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Mints value branded tokens, approves gateway to transfer
+     *         the amount of minted value branded tokens from the staker, and
+     *         deletes stake request.
+     *
+     * @dev It is expected that this contract will have a sufficient allowance to
+     *      transfer value tokens from the staker at the time this function is executed.
+     *
+     *      Function requires:
+     *          - TBD.
+     */
+    function acceptStakeRequest(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Transfers value tokens to staker and deletes stake request.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function rejectStakeRequest(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Transfers an amount of value tokens corresponding to the amount of redeemed value branded tokens to msg.sender.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function redeem(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Returns the total supply of value branded tokens.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function totalSupply() external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Returns the value branded tokens balance of _owner.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function balanceOf(address) external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Returns the amount of value branded tokens _spender is approved
+     *         to transfer from _owner.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function allowance(address, address) external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Transfers _amount of value branded tokens to _to.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function transfer(address, uint256) public returns (bool) {
+        // TODO
+    }
+
+    /**
+     * @notice Transfers _amount of value branded tokens from _from to _to.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function transferFrom(address, address, uint256) public returns (bool) {
+        // TODO
+    }
+
+    /**
+     * @notice Sets an _amount of value branded tokens _spender is approved
+     *         to _transfer.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function approve(address, uint256) public returns (bool) {
+        // TODO
+    }
+}

--- a/contracts/truffle/Migrations.sol
+++ b/contracts/truffle/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 contract Migrations {
 

--- a/test/value_branded_token/constructor.js
+++ b/test/value_branded_token/constructor.js
@@ -1,0 +1,54 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+const utils = require('../test_lib/utils.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+
+const ValueBrandedToken = artifacts.require('ValueBrandedToken');
+
+contract('ValueBrandedToken::constructor', async () => {
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Reverts if valueToken is null', async () => {
+            const valueToken = utils.NULL_ADDRESS;
+
+            await utils.expectRevert(
+                ValueBrandedToken.new(
+                    valueToken,
+                ),
+                'Should revert as valueToken is null.',
+                'ValueToken is null.',
+            );
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully sets the constructor arguments', async () => {
+            const valueToken = accountProvider.get();
+
+            const valueBrandedToken = await ValueBrandedToken.new(
+                valueToken,
+            );
+
+            assert.strictEqual(
+                (await valueBrandedToken.valueToken.call()),
+                valueToken,
+            );
+        });
+    });
+});


### PR DESCRIPTION
To lay the groundwork for implementing the ValueBrandedToken spec, this PR:
- adds solium config files for linting
- adds EIP20 interface
  - breaks down EIP20 into optional and required interfaces (to minimize unnecessary functionality)
  - uses an EIP20Interface contract that inherits the optional and required interfaces instead of the EIP20Interface contract used in other OpenST repositories (to ensure compatibility with any existing contracts that will be moved into this repo that expect a fulsome EIP20Interface)
- adds ValueBrandedToken
  - imports EIP20 required interface (resolves #3)
  - inherits EIP20 required interface (and gives function skeletons because otherwise the contract would be an abstract which would make it undeployable and therefore untestable, but I would prefer to inherit from the outset to ensure inheritance is in the code) (resolves #4)
  - constructs with value token address (resolves #8)
  - gives function skeletons for non-EIP20 functions guidance

Resolves #2.

✅ linted
✅ tested
✅ changelogged