### PR TITLE
Contracts: request stake

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,3 @@
+node_modules
+contracts/Migrations.sol
+contracts/SafeMath.sol

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": "solium:recommended",
+  "plugins": [
+    "security"
+  ],
+  "rules": {
+    "imports-on-top": 0,
+    "variable-declarations": 0,
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "indentation": [
+      "error",
+      4
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 0.0.0
+
+- Contracts: add value token to constructor ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: inherit EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: import EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: setup repo and add ValueBrandedToken contract ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.0.0
 
+- Contracts: complete stake requested event  ([#30](https://github.com/OpenSTFoundation/openst-tokens/pull/30))
+- Contracts: add requestStake  ([#30](https://github.com/OpenSTFoundation/openst-tokens/pull/30))
 - Contracts: add value token to constructor ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
 - Contracts: inherit EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
 - Contracts: import EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))

--- a/contracts/EIP20TokenInterface.sol
+++ b/contracts/EIP20TokenInterface.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+import "./EIP20TokenOptionalInterface.sol";
+import "./EIP20TokenRequiredInterface.sol";
+
+
+/**
+ *  @title EIP20 Token Interface.
+ *
+ *  @notice Provides EIP20 token interface.
+ */
+/* solium-disable-next-line no-empty-blocks */ 
+contract EIP20TokenInterface is EIP20TokenOptionalInterface, EIP20TokenRequiredInterface { }

--- a/contracts/EIP20TokenOptionalInterface.sol
+++ b/contracts/EIP20TokenOptionalInterface.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title EIP20 Token Optional Interface.
+ *
+ *  @notice Provides optional function signatures for EIP20 token interface.
+ */
+interface EIP20TokenOptionalInterface {
+
+    /** Public Functions */
+
+    function name() external view returns (string);
+    function symbol() external view returns (string);
+    function decimals() external view returns (uint8);
+}

--- a/contracts/EIP20TokenRequiredInterface.sol
+++ b/contracts/EIP20TokenRequiredInterface.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title EIP20 Token Required Interface.
+ *
+ *  @notice Provides required function signatures and
+ *          event declarations for EIP20 token interface.
+ */
+interface EIP20TokenRequiredInterface {
+
+    /* Events */
+
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+
+
+    /* Public Functions */
+
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address _owner) external view returns (uint256 balance);
+    function allowance(address _owner, address _spender) external view returns (uint256 remaining);
+    function transfer(address _to, uint256 _value) external returns (bool success);
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool success);
+    function approve(address _spender, uint256 _value) external returns (bool success);
+}

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
+
 
 // Copyright 2018 OpenST Ltd.
 //
@@ -13,7 +14,7 @@ pragma solidity ^0.4.23;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // ----------------------------------------------------------------------------
 // Common: SafeMath Library Implementation
 //
@@ -27,41 +28,71 @@ pragma solidity ^0.4.23;
 
 
 /**
-   @title SafeMath
-   @notice Implements SafeMath
-*/
+ * @title SafeMath
+ * @dev Math operations with safety checks that revert on error.
+ */
 library SafeMath {
 
+    /**
+     * @dev Multiplies two numbers, reverts on overflow.
+     */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-        uint256 c = a * b;
+        // Gas optimization: this is cheaper than requiring 'a' not being zero,
+        // but the benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+        if (a == 0) {
+            return 0;
+        }
 
-        assert(a == 0 || c / a == b);
+        uint256 c = a * b;
+        require(c / a == b);
 
         return c;
     }
 
-
+    /**
+     * @dev Integer division of two numbers truncating the quotient, reverts
+     *      on division by zero.
+     */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Solidity automatically throws when dividing by 0
+        // Solidity only automatically asserts when dividing by 0.
+        require(b > 0);
         uint256 c = a / b;
 
-        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+        // There is no case in which this doesn't hold
+        // assert(a == b * c + a % b);
+
         return c;
     }
 
-
+    /**
+     * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is
+     *      greater than minuend).
+     *
+     */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-        assert(b <= a);
+        require(b <= a);
+        uint256 c = a - b;
 
-        return a - b;
+        return c;
     }
 
-
+    /**
+     * @dev Adds two numbers, reverts on overflow.
+     */
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;
-
-        assert(c >= a);
+        require(c >= a);
 
         return c;
+    }
+
+    /**
+     * @dev Divides two numbers and returns the remainder,
+     *      (unsigned integer modulo) reverts when dividing by zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0);
+        return a % b;
     }
 }

--- a/contracts/ValueBrandedToken.sol
+++ b/contracts/ValueBrandedToken.sol
@@ -1,0 +1,202 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import "./SafeMath.sol";
+import "./EIP20TokenRequiredInterface.sol";
+
+
+/**
+ * @title Value Branded Token.
+ *
+ * @notice Supports staking value tokens for minting utility branded tokens
+ *         where the conversion rate from value token to utility branded token
+ *         is not 1:1.
+ */
+contract ValueBrandedToken is EIP20TokenRequiredInterface {
+
+    /* Usings */
+
+    using SafeMath for uint256;
+
+
+    /* Events */
+
+    event StakeRequested(/*...*/);
+
+    event StakeRequestAccepted(/*...*/);
+
+    event StakeRequestRejected(/*...*/);
+
+
+    /* Storage */
+
+    EIP20TokenRequiredInterface public valueToken;
+
+    mapping(address /* staker */ => uint256 /* value branded tokens */) public stakeRequests;
+
+    /* Constructor */
+
+    /**
+     * @dev Constructor requires:
+     *          - valueToken address is not null.
+     *
+     * @param _valueToken Address for tokens staked to mint utility branded tokens.
+     */
+    constructor(
+        EIP20TokenRequiredInterface _valueToken
+        // TODO: conversion-rate-related parameters
+    )
+        public
+    {
+        require(
+            _valueToken != address(0),
+            "ValueToken is null."
+        );
+
+        valueToken = _valueToken;
+    }
+
+
+    /* External Functions */
+
+    /**
+     * @notice Transfers value tokens from msg.sender to itself,
+     *         stores the amount of value branded tokens to mint if request is accepted,
+     *         and emits information required to stake value branded tokens
+     *         to mint utility branded tokens.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function requestStake(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Mints value branded tokens, approves gateway to transfer
+     *         the amount of minted value branded tokens from the staker, and
+     *         deletes stake request.
+     *
+     * @dev It is expected that this contract will have a sufficient allowance to
+     *      transfer value tokens from the staker at the time this function is executed.
+     *
+     *      Function requires:
+     *          - TBD.
+     */
+    function acceptStakeRequest(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Transfers value tokens to staker and deletes stake request.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function rejectStakeRequest(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Transfers an amount of value tokens corresponding to the amount of redeemed value branded tokens to msg.sender.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function redeem(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Returns the total supply of value branded tokens.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function totalSupply() external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Returns the value branded tokens balance of _owner.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function balanceOf(address) external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Returns the amount of value branded tokens _spender is approved
+     *         to transfer from _owner.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function allowance(address, address) external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Transfers _amount of value branded tokens to _to.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function transfer(address, uint256) public returns (bool) {
+        // TODO
+    }
+
+    /**
+     * @notice Transfers _amount of value branded tokens from _from to _to.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function transferFrom(address, address, uint256) public returns (bool) {
+        // TODO
+    }
+
+    /**
+     * @notice Sets an _amount of value branded tokens _spender is approved
+     *         to _transfer.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function approve(address, uint256) public returns (bool) {
+        // TODO
+    }
+}

--- a/contracts/test/EIP20TokenMockFail.sol
+++ b/contracts/test/EIP20TokenMockFail.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title Mock EIP20 Token Fail.
+ *
+ *  @notice Mocks EIP20 token functions as failing.
+ */
+contract EIP20TokenMockFail {
+
+    /* External Functions */
+
+    /**
+     * @notice Mocks failing transfer from.
+     *
+     * @return bool False.
+     */
+    function transferFrom(
+        address,
+        address,
+        uint256
+    )
+        external
+        pure
+        returns (bool)
+    {
+        return false;
+    }
+}

--- a/contracts/test/EIP20TokenMockPass.sol
+++ b/contracts/test/EIP20TokenMockPass.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title Mock EIP20 Token Pass.
+ *
+ *  @notice Mocks EIP20 token functions as passing.
+ */
+contract EIP20TokenMockPass {
+
+    /* External Functions */
+
+    /**
+     * @notice Mocks passing transfer from.
+     *
+     * @return bool True.
+     */
+    function transferFrom(
+        address,
+        address,
+        uint256
+    )
+        external
+        pure
+        returns (bool)
+    {
+        return true;
+    }
+}

--- a/contracts/test/EIP20TokenMockPassFail.sol
+++ b/contracts/test/EIP20TokenMockPassFail.sol
@@ -20,11 +20,11 @@ pragma solidity ^0.4.24;
 
 
 /**
- *  @title Mock EIP20 Token Pass.
+ *  @title Mock EIP20 Token Pass Fail.
  *
- *  @notice Mocks EIP20 token functions as passing.
+ *  @notice Mocks EIP20 token transferFrom as passing and transfer as failing.
  */
-contract EIP20TokenMockPass {
+contract EIP20TokenMockPassFail {
 
     /* External Functions */
 
@@ -46,9 +46,9 @@ contract EIP20TokenMockPass {
     }
 
     /**
-     * @notice Mocks passing transfer.
+     * @notice Mocks failing transfer.
      *
-     * @return bool true.
+     * @return bool False.
      */
     function transfer(
         address,
@@ -58,6 +58,6 @@ contract EIP20TokenMockPass {
         pure
         returns (bool)
     {
-        return true;
+        return false;
     }
 }

--- a/contracts/truffle/Migrations.sol
+++ b/contracts/truffle/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 contract Migrations {
 

--- a/test/test_lib/utils.js
+++ b/test/test_lib/utils.js
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const BN = require('bn.js');
 const assert = require('assert');
 const web3 = require('./web3.js');
 
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+const zeroBN = new BN(0);
 
 module.exports.NULL_ADDRESS = NULL_ADDRESS;
 
 module.exports.isNullAddress = address => address === NULL_ADDRESS;
+
+module.exports.zeroBN = zeroBN;
 
 /**
  * Asserts that a call or transaction reverts.

--- a/test/value_branded_token/constructor.js
+++ b/test/value_branded_token/constructor.js
@@ -1,0 +1,54 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+const utils = require('../test_lib/utils.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+
+const ValueBrandedToken = artifacts.require('ValueBrandedToken');
+
+contract('ValueBrandedToken::constructor', async () => {
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Reverts if valueToken is null', async () => {
+            const valueToken = utils.NULL_ADDRESS;
+
+            await utils.expectRevert(
+                ValueBrandedToken.new(
+                    valueToken,
+                ),
+                'Should revert as valueToken is null.',
+                'ValueToken is null.',
+            );
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully sets the constructor arguments', async () => {
+            const valueToken = accountProvider.get();
+
+            const valueBrandedToken = await ValueBrandedToken.new(
+                valueToken,
+            );
+
+            assert.strictEqual(
+                (await valueBrandedToken.valueToken.call()),
+                valueToken,
+            );
+        });
+    });
+});

--- a/test/value_branded_token/request_stake.js
+++ b/test/value_branded_token/request_stake.js
@@ -239,10 +239,12 @@ contract('ValueBrandedToken::requestStake', async () => {
 
             const staker = accountProvider.get();
 
-            const amountBeforeRequest = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+            const amountBeforeRequest = await valueBrandedToken.stakeRequests.call(staker);
 
             assert.strictEqual(
-                amountBeforeRequest,
+                amountBeforeRequest.cmp(
+                    utils.zeroBN,
+                ),
                 0,
             );
 
@@ -257,16 +259,20 @@ contract('ValueBrandedToken::requestStake', async () => {
                 { from: staker },
             );
 
-            const amountAfterRequest = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+            const amountAfterRequest = await valueBrandedToken.stakeRequests.call(staker)
 
-            assert.notStrictEqual(
-                amountBeforeRequest,
-                amountAfterRequest,
+            assert.strictEqual(
+                amountBeforeRequest.cmp(
+                    amountAfterRequest,
+                ),
+                -1,
             );
 
             assert.strictEqual(
-                amountAfterRequest,
-                valueTokens,
+                amountAfterRequest.cmp(
+                    new BN(valueTokens),
+                ),
+                0,
             );
         });
     });

--- a/test/value_branded_token/request_stake.js
+++ b/test/value_branded_token/request_stake.js
@@ -1,0 +1,273 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+const BN = require('bn.js');
+const utils = require('../test_lib/utils.js');
+const { Event } = require('../test_lib/event_decoder');
+const { AccountProvider } = require('../test_lib/utils.js');
+const ValueBrandedTokenUtils = require('./utils.js');
+
+const EIP20TokenMockFail = artifacts.require('EIP20TokenMockFail');
+const ValueBrandedToken = artifacts.require('ValueBrandedToken');
+
+contract('ValueBrandedToken::requestStake', async () => {
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        const gasPrice = 0;
+        const gasLimit = 0;
+        const nonce = 0;
+
+        const staker = accountProvider.get();
+
+        it('Reverts if valueTokens is zero', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 0;
+            const valueBrandedTokens = 0;
+            const signature = '0x00';
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    valueTokens,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as valueTokens is zero.',
+                'ValueTokens is zero.',
+            );
+        });
+
+        it('Reverts if beneficiary is null', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = utils.NULL_ADDRESS;
+            const signature = '0x00';
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as beneficiary is null.',
+                'Beneficiary is null.',
+            );
+        });
+
+        it('Reverts if signature is empty', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const signature = '0x';
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as signature is empty.',
+                'Signature is empty.',
+            );
+        });
+
+        it('Reverts if staker has a stake request', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+
+            await valueBrandedToken.requestStake(
+                valueTokens,
+                valueBrandedTokens,
+                beneficiary,
+                gasPrice,
+                gasLimit,
+                nonce,
+                signature,
+                { from: staker },
+            );
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as staker has a stake request.',
+                'Staker has a stake request.',
+            );
+        });
+
+        it('Reverts if valueToken.transferFrom returns false', async () => {
+            const valueToken = await EIP20TokenMockFail.new();
+            const valueBrandedToken = await ValueBrandedToken.new(
+                valueToken.address,
+            );
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as valueToken.transferFrom returned false.',
+                'ValueToken.transferFrom returned false.',
+            );
+        });
+    });
+
+    contract('Events', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Emits StakeRequested event', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 0;
+            const gasLimit = 0;
+            const nonce = 0;
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+
+            const transactionResponse = await valueBrandedToken.requestStake(
+                valueTokens,
+                valueBrandedTokens,
+                beneficiary,
+                gasPrice,
+                gasLimit,
+                nonce,
+                signature,
+                { from: staker },
+            );
+
+            const events = Event.decodeTransactionResponse(
+                transactionResponse,
+            );
+
+            assert.strictEqual(
+                events.length,
+                1,
+                'Only StakeRequested event should be emitted.',
+            );
+
+            Event.assertEqual(events[0], {
+                name: 'StakeRequested',
+                args: {
+                    _valueTokens: new BN(valueTokens),
+                    _valueBrandedTokens: new BN(valueBrandedTokens),
+                    _beneficiary: beneficiary,
+                    _staker: staker,
+                    _gasPrice: new BN(gasPrice),
+                    _gasLimit: new BN(gasLimit),
+                    _nonce: new BN(nonce),
+                    _signature: signature,
+                },
+            });
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully stores stake request', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 0;
+            const gasLimit = 0;
+            const nonce = 0;
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+
+            const amountBeforeRequest = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+
+            assert.strictEqual(
+                amountBeforeRequest,
+                0,
+            );
+
+            await valueBrandedToken.requestStake(
+                valueTokens,
+                valueBrandedTokens,
+                beneficiary,
+                gasPrice,
+                gasLimit,
+                nonce,
+                signature,
+                { from: staker },
+            );
+
+            const amountAfterRequest = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+
+            assert.notStrictEqual(
+                amountBeforeRequest,
+                amountAfterRequest,
+            );
+
+            assert.strictEqual(
+                amountAfterRequest,
+                valueTokens,
+            );
+        });
+    });
+});

--- a/test/value_branded_token/utils.js
+++ b/test/value_branded_token/utils.js
@@ -1,0 +1,28 @@
+// Copyright 2018 OST.com Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const EIP20TokenMockPass = artifacts.require('EIP20TokenMockPass');
+const ValueBrandedToken = artifacts.require('ValueBrandedToken');
+
+/**
+ * Creates a value branded token.
+ */
+module.exports.createValueBrandedToken = async () => {
+    const valueToken = await EIP20TokenMockPass.new();
+    const valueBrandedToken = await ValueBrandedToken.new(
+        valueToken.address,
+    );
+
+    return valueBrandedToken;
+};

--- a/test/value_branded_token/utils.js
+++ b/test/value_branded_token/utils.js
@@ -26,3 +26,37 @@ module.exports.createValueBrandedToken = async () => {
 
     return valueBrandedToken;
 };
+
+/**
+ * Creates a value branded token and a stake request.
+ */
+module.exports.createValueBrandedTokenAndStakeRequest = async (accountProvider) => {
+    const valueBrandedToken = await this.createValueBrandedToken();
+
+    const valueTokens = 1;
+    const valueBrandedTokens = 0;
+    const beneficiary = accountProvider.get();
+    const gasPrice = 0;
+    const gasLimit = 0;
+    const nonce = 0;
+    const signature = '0x00';
+
+    const staker = accountProvider.get();
+
+    await valueBrandedToken.requestStake(
+        valueTokens,
+        valueBrandedTokens,
+        beneficiary,
+        gasPrice,
+        gasLimit,
+        nonce,
+        signature,
+        { from: staker },
+    );
+
+    return {
+        valueBrandedToken,
+        valueTokens,
+        staker,
+    };
+};


### PR DESCRIPTION
🚫 Not to be considered until after #25 is merged.

This PR:
- adds request stake function (resolves #12)
- completes and applies stake requested event (resolves #14)

N.B.: at L46 in `request_stake.js`, there is an error (doesn't impact the test) that is corrected in #38 (`valueTokens` instead of `beneficiary`).

✅ linted
✅ tested
✅ changelogged

Diff against branching point: https://github.com/jasonklein/openst-tokens/compare/jasonbanks/initialize-value-branded-token...jasonklein:jasonbanks/gh12/request-stake-function