### PR TITLE
Contracts: conversion

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,3 @@
+node_modules
+contracts/Migrations.sol
+contracts/SafeMath.sol

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": "solium:recommended",
+  "plugins": [
+    "security"
+  ],
+  "rules": {
+    "imports-on-top": 0,
+    "variable-declarations": 0,
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "indentation": [
+      "error",
+      4
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 0.0.0
 
-- Contracts: complete stake requested event  ([#30](https://github.com/OpenSTFoundation/openst-tokens/pull/30))
-- Contracts: add requestStake  ([#30](https://github.com/OpenSTFoundation/openst-tokens/pull/30))
+- Contracts: complete EIP20 view functions ([#32](https://github.com/OpenSTFoundation/openst-tokens/pull/32))
+- Contracts: complete stake request accepted event ([#32](https://github.com/OpenSTFoundation/openst-tokens/pull/32))
+- Contracts: add acceptStakeRequest ([#32](https://github.com/OpenSTFoundation/openst-tokens/pull/32))
+- Contracts: complete stake requested event ([#30](https://github.com/OpenSTFoundation/openst-tokens/pull/30))
+- Contracts: add requestStake ([#30](https://github.com/OpenSTFoundation/openst-tokens/pull/30))
 - Contracts: add value token to constructor ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
 - Contracts: inherit EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
 - Contracts: import EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.0.0
 
+- Contracts: transfer equivalent value tokens to redeemers in redeem ([#38](https://github.com/OpenSTFoundation/openst-tokens/pull/38))
+- Contracts: require equivalence between value tokens and value branded tokens in requestStake ([#38](https://github.com/OpenSTFoundation/openst-tokens/pull/38))
+- Contracts: complete function for converting from value tokens to value branded tokens ([#38](https://github.com/OpenSTFoundation/openst-tokens/pull/38))
+- Contracts: update the constructor to take conversion rate information ([#38](https://github.com/OpenSTFoundation/openst-tokens/pull/38))
 - Contracts: add redeem ([#33](https://github.com/OpenSTFoundation/openst-tokens/pull/33))
 - Contracts: complete EIP20 view functions ([#32](https://github.com/OpenSTFoundation/openst-tokens/pull/32))
 - Contracts: complete stake request accepted event ([#32](https://github.com/OpenSTFoundation/openst-tokens/pull/32))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.0
 
+- Contracts: add redeem ([#33](https://github.com/OpenSTFoundation/openst-tokens/pull/33))
 - Contracts: complete EIP20 view functions ([#32](https://github.com/OpenSTFoundation/openst-tokens/pull/32))
 - Contracts: complete stake request accepted event ([#32](https://github.com/OpenSTFoundation/openst-tokens/pull/32))
 - Contracts: add acceptStakeRequest ([#32](https://github.com/OpenSTFoundation/openst-tokens/pull/32))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 0.0.0
+
+- Contracts: add value token to constructor ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: inherit EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: import EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
+- Contracts: setup repo and add ValueBrandedToken contract ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.0.0
 
+- Contracts: complete stake requested event  ([#30](https://github.com/OpenSTFoundation/openst-tokens/pull/30))
+- Contracts: add requestStake  ([#30](https://github.com/OpenSTFoundation/openst-tokens/pull/30))
 - Contracts: add value token to constructor ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
 - Contracts: inherit EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))
 - Contracts: import EIP20 interface ([#25](https://github.com/OpenSTFoundation/openst-tokens/pull/25))

--- a/contracts/EIP20TokenInterface.sol
+++ b/contracts/EIP20TokenInterface.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+import "./EIP20TokenOptionalInterface.sol";
+import "./EIP20TokenRequiredInterface.sol";
+
+
+/**
+ *  @title EIP20 Token Interface.
+ *
+ *  @notice Provides EIP20 token interface.
+ */
+/* solium-disable-next-line no-empty-blocks */ 
+contract EIP20TokenInterface is EIP20TokenOptionalInterface, EIP20TokenRequiredInterface { }

--- a/contracts/EIP20TokenOptionalInterface.sol
+++ b/contracts/EIP20TokenOptionalInterface.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title EIP20 Token Optional Interface.
+ *
+ *  @notice Provides optional function signatures for EIP20 token interface.
+ */
+interface EIP20TokenOptionalInterface {
+
+    /** Public Functions */
+
+    function name() external view returns (string);
+    function symbol() external view returns (string);
+    function decimals() external view returns (uint8);
+}

--- a/contracts/EIP20TokenRequiredInterface.sol
+++ b/contracts/EIP20TokenRequiredInterface.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title EIP20 Token Required Interface.
+ *
+ *  @notice Provides required function signatures and
+ *          event declarations for EIP20 token interface.
+ */
+interface EIP20TokenRequiredInterface {
+
+    /* Events */
+
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+
+
+    /* Public Functions */
+
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address _owner) external view returns (uint256 balance);
+    function allowance(address _owner, address _spender) external view returns (uint256 remaining);
+    function transfer(address _to, uint256 _value) external returns (bool success);
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool success);
+    function approve(address _spender, uint256 _value) external returns (bool success);
+}

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
+
 
 // Copyright 2018 OpenST Ltd.
 //
@@ -13,7 +14,7 @@ pragma solidity ^0.4.23;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // ----------------------------------------------------------------------------
 // Common: SafeMath Library Implementation
 //
@@ -27,41 +28,71 @@ pragma solidity ^0.4.23;
 
 
 /**
-   @title SafeMath
-   @notice Implements SafeMath
-*/
+ * @title SafeMath
+ * @dev Math operations with safety checks that revert on error.
+ */
 library SafeMath {
 
+    /**
+     * @dev Multiplies two numbers, reverts on overflow.
+     */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-        uint256 c = a * b;
+        // Gas optimization: this is cheaper than requiring 'a' not being zero,
+        // but the benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+        if (a == 0) {
+            return 0;
+        }
 
-        assert(a == 0 || c / a == b);
+        uint256 c = a * b;
+        require(c / a == b);
 
         return c;
     }
 
-
+    /**
+     * @dev Integer division of two numbers truncating the quotient, reverts
+     *      on division by zero.
+     */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Solidity automatically throws when dividing by 0
+        // Solidity only automatically asserts when dividing by 0.
+        require(b > 0);
         uint256 c = a / b;
 
-        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+        // There is no case in which this doesn't hold
+        // assert(a == b * c + a % b);
+
         return c;
     }
 
-
+    /**
+     * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is
+     *      greater than minuend).
+     *
+     */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-        assert(b <= a);
+        require(b <= a);
+        uint256 c = a - b;
 
-        return a - b;
+        return c;
     }
 
-
+    /**
+     * @dev Adds two numbers, reverts on overflow.
+     */
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;
-
-        assert(c >= a);
+        require(c >= a);
 
         return c;
+    }
+
+    /**
+     * @dev Divides two numbers and returns the remainder,
+     *      (unsigned integer modulo) reverts when dividing by zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b != 0);
+        return a % b;
     }
 }

--- a/contracts/ValueBrandedToken.sol
+++ b/contracts/ValueBrandedToken.sol
@@ -215,17 +215,37 @@ contract ValueBrandedToken is EIP20TokenRequiredInterface {
     }
 
     /**
-     * @notice Transfers an amount of value tokens corresponding to the amount of redeemed value branded tokens to msg.sender.
+     * @notice Reduces msg.sender's balance and the supply by _valueBrandedTokens
+     *         and transfers an equivalent amount of value tokens to msg.sender.
      *
      * @dev Function requires:
-     *          - TBD.
+     *          - msg.sender has a balance at least equal to _valueBrandedTokens;
+     *          - valueToken.transfer returns true.
+     *
+     * @param _valueBrandedTokens Amount of value branded tokens to redeem.
+     *
+     * @return valueTokens_ Amount of value tokens transferred to redeemer.
      */
     function redeem(
+        uint256 _valueBrandedTokens
     )
         external
-        // TODO: returns
+        returns (uint256 valueTokens_)
     {
-        /*...*/
+        balances[msg.sender] = balances[msg.sender].sub(_valueBrandedTokens);
+
+        assert(supply >= _valueBrandedTokens);
+
+        supply = supply.sub(_valueBrandedTokens);
+
+        emit Transfer(msg.sender, address(0), _valueBrandedTokens);
+
+        valueTokens_ = _valueBrandedTokens; // TODO: replace with proper conversion
+
+        require(
+            valueToken.transfer(msg.sender, valueTokens_),
+            "ValueToken.transfer returned false."
+        );
     }
 
     /**

--- a/contracts/ValueBrandedToken.sol
+++ b/contracts/ValueBrandedToken.sol
@@ -1,0 +1,202 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import "./SafeMath.sol";
+import "./EIP20TokenRequiredInterface.sol";
+
+
+/**
+ * @title Value Branded Token.
+ *
+ * @notice Supports staking value tokens for minting utility branded tokens
+ *         where the conversion rate from value token to utility branded token
+ *         is not 1:1.
+ */
+contract ValueBrandedToken is EIP20TokenRequiredInterface {
+
+    /* Usings */
+
+    using SafeMath for uint256;
+
+
+    /* Events */
+
+    event StakeRequested(/*...*/);
+
+    event StakeRequestAccepted(/*...*/);
+
+    event StakeRequestRejected(/*...*/);
+
+
+    /* Storage */
+
+    EIP20TokenRequiredInterface public valueToken;
+
+    mapping(address /* staker */ => uint256 /* value branded tokens */) public stakeRequests;
+
+    /* Constructor */
+
+    /**
+     * @dev Constructor requires:
+     *          - valueToken address is not null.
+     *
+     * @param _valueToken Address for tokens staked to mint utility branded tokens.
+     */
+    constructor(
+        EIP20TokenRequiredInterface _valueToken
+        // TODO: conversion-rate-related parameters
+    )
+        public
+    {
+        require(
+            _valueToken != address(0),
+            "ValueToken is null."
+        );
+
+        valueToken = _valueToken;
+    }
+
+
+    /* External Functions */
+
+    /**
+     * @notice Transfers value tokens from msg.sender to itself,
+     *         stores the amount of value branded tokens to mint if request is accepted,
+     *         and emits information required to stake value branded tokens
+     *         to mint utility branded tokens.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function requestStake(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Mints value branded tokens, approves gateway to transfer
+     *         the amount of minted value branded tokens from the staker, and
+     *         deletes stake request.
+     *
+     * @dev It is expected that this contract will have a sufficient allowance to
+     *      transfer value tokens from the staker at the time this function is executed.
+     *
+     *      Function requires:
+     *          - TBD.
+     */
+    function acceptStakeRequest(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Transfers value tokens to staker and deletes stake request.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function rejectStakeRequest(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Transfers an amount of value tokens corresponding to the amount of redeemed value branded tokens to msg.sender.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function redeem(
+    )
+        external
+        // TODO: returns
+    {
+        /*...*/
+    }
+
+    /**
+     * @notice Returns the total supply of value branded tokens.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function totalSupply() external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Returns the value branded tokens balance of _owner.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function balanceOf(address) external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Returns the amount of value branded tokens _spender is approved
+     *         to transfer from _owner.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function allowance(address, address) external view returns (uint256) {
+        // TODO
+    }
+
+    /**
+     * @notice Transfers _amount of value branded tokens to _to.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function transfer(address, uint256) public returns (bool) {
+        // TODO
+    }
+
+    /**
+     * @notice Transfers _amount of value branded tokens from _from to _to.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function transferFrom(address, address, uint256) public returns (bool) {
+        // TODO
+    }
+
+    /**
+     * @notice Sets an _amount of value branded tokens _spender is approved
+     *         to _transfer.
+     *
+     * @dev Function requires:
+     *          - TBD.
+     */
+    function approve(address, uint256) public returns (bool) {
+        // TODO
+    }
+}

--- a/contracts/ValueBrandedToken.sol
+++ b/contracts/ValueBrandedToken.sol
@@ -25,7 +25,9 @@ import "./EIP20TokenRequiredInterface.sol";
  *
  * @notice Supports staking value tokens for minting utility branded tokens
  *         where the conversion rate from value token to utility branded token
- *         is not 1:1.
+ *         is not 1:1. This contract does not require a non-1:1 conversion rate,
+ *         but it is expected that if the conversion rate is 1:1, value tokens
+ *         will be staked directly through a Gateway.
  */
 contract ValueBrandedToken is EIP20TokenRequiredInterface {
 
@@ -60,6 +62,8 @@ contract ValueBrandedToken is EIP20TokenRequiredInterface {
     EIP20TokenRequiredInterface public valueToken;
     address public gateway;
     uint256 private supply;
+    uint256 public conversionRate;
+    uint8 public conversionRateDecimals;
 
     mapping(address /* staker */ => uint256 /* value tokens */) public stakeRequests;
     mapping(address => uint256 /* value branded tokens */) private balances;
@@ -68,14 +72,24 @@ contract ValueBrandedToken is EIP20TokenRequiredInterface {
     /* Constructor */
 
     /**
-     * @dev Constructor requires:
-     *          - valueToken address is not null.
+     * @dev Conversion parameters provide the conversion rate and its scale.
+     *      For example, if 1 value token is equivalent to 3.5 utility branded
+     *      tokens (1:3.5), _conversionRate == 35 and _conversionRateDecimals == 1.
+     *
+     *      Constructor requires:
+     *          - valueToken address is not null,
+     *          - conversionRate is not zero.
      *
      * @param _valueToken Address for tokens staked to mint utility branded tokens.
+     * @param _conversionRate Conversion rate from value tokens to utility branded
+     *        tokens.
+     * @param _conversionRateDecimals Number of digits to the right of the
+     *        decimal point in _conversionRate.
      */
     constructor(
-        EIP20TokenRequiredInterface _valueToken
-        // TODO: conversion-rate-related parameters
+        EIP20TokenRequiredInterface _valueToken,
+        uint256 _conversionRate,
+        uint8 _conversionRateDecimals
     )
         public
     {
@@ -83,8 +97,14 @@ contract ValueBrandedToken is EIP20TokenRequiredInterface {
             _valueToken != address(0),
             "ValueToken is null."
         );
+        require(
+            _conversionRate != 0,
+            "ConversionRate is zero."
+        );
 
         valueToken = _valueToken;
+        conversionRate = _conversionRate;
+        conversionRateDecimals = _conversionRateDecimals;
     }
 
 

--- a/contracts/test/EIP20TokenMockFail.sol
+++ b/contracts/test/EIP20TokenMockFail.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title Mock EIP20 Token Fail.
+ *
+ *  @notice Mocks EIP20 token functions as failing.
+ */
+contract EIP20TokenMockFail {
+
+    /* External Functions */
+
+    /**
+     * @notice Mocks failing transfer from.
+     *
+     * @return bool False.
+     */
+    function transferFrom(
+        address,
+        address,
+        uint256
+    )
+        external
+        pure
+        returns (bool)
+    {
+        return false;
+    }
+}

--- a/contracts/test/EIP20TokenMockPass.sol
+++ b/contracts/test/EIP20TokenMockPass.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.4.24;
+
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on the 'final' EIP20 token standard as specified at:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
+
+
+/**
+ *  @title Mock EIP20 Token Pass.
+ *
+ *  @notice Mocks EIP20 token functions as passing.
+ */
+contract EIP20TokenMockPass {
+
+    /* External Functions */
+
+    /**
+     * @notice Mocks passing transfer from.
+     *
+     * @return bool True.
+     */
+    function transferFrom(
+        address,
+        address,
+        uint256
+    )
+        external
+        pure
+        returns (bool)
+    {
+        return true;
+    }
+}

--- a/contracts/test/EIP20TokenMockPassFail.sol
+++ b/contracts/test/EIP20TokenMockPassFail.sol
@@ -20,11 +20,11 @@ pragma solidity ^0.4.24;
 
 
 /**
- *  @title Mock EIP20 Token Pass.
+ *  @title Mock EIP20 Token Pass Fail.
  *
- *  @notice Mocks EIP20 token functions as passing.
+ *  @notice Mocks EIP20 token transferFrom as passing and transfer as failing.
  */
-contract EIP20TokenMockPass {
+contract EIP20TokenMockPassFail {
 
     /* External Functions */
 
@@ -46,9 +46,9 @@ contract EIP20TokenMockPass {
     }
 
     /**
-     * @notice Mocks passing transfer.
+     * @notice Mocks failing transfer.
      *
-     * @return bool true.
+     * @return bool False.
      */
     function transfer(
         address,
@@ -58,6 +58,6 @@ contract EIP20TokenMockPass {
         pure
         returns (bool)
     {
-        return true;
+        return false;
     }
 }

--- a/contracts/truffle/Migrations.sol
+++ b/contracts/truffle/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 contract Migrations {
 

--- a/test/test_lib/utils.js
+++ b/test/test_lib/utils.js
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const BN = require('bn.js');
 const assert = require('assert');
 const web3 = require('./web3.js');
 
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+const zeroBN = new BN(0);
 
 module.exports.NULL_ADDRESS = NULL_ADDRESS;
 
 module.exports.isNullAddress = address => address === NULL_ADDRESS;
+
+module.exports.zeroBN = zeroBN;
 
 /**
  * Asserts that a call or transaction reverts.

--- a/test/value_branded_token/accept_stake_request.js
+++ b/test/value_branded_token/accept_stake_request.js
@@ -109,28 +109,36 @@ contract('ValueBrandedToken::acceptStakeRequest', async () => {
             } = await ValueBrandedTokenUtils.createValueBrandedTokenAndStakeRequest(accountProvider);
 
             const gateway = await valueBrandedToken.gateway.call();
-            const stakeRequestBefore = (await valueBrandedToken.stakeRequests(staker)).toNumber();
-            const balanceBefore = (await valueBrandedToken.balanceOf(staker)).toNumber();
-            const totalSupplyBefore = (await valueBrandedToken.totalSupply()).toNumber();
-            const allowanceBefore = (await valueBrandedToken.allowance(staker, gateway)).toNumber();
+            const stakeRequestBefore = await valueBrandedToken.stakeRequests.call(staker);
+            const balanceBefore = await valueBrandedToken.balanceOf.call(staker);
+            const totalSupplyBefore = await valueBrandedToken.totalSupply.call();
+            const allowanceBefore = await valueBrandedToken.allowance.call(staker, gateway);
 
-            assert.isAbove(
-                stakeRequestBefore,
+            assert.strictEqual(
+                stakeRequestBefore.cmp(
+                    utils.zeroBN,
+                ),
+                1,
+            );
+
+            assert.strictEqual(
+                balanceBefore.cmp(
+                    utils.zeroBN,
+                ),
                 0,
             );
 
             assert.strictEqual(
-                balanceBefore,
+                totalSupplyBefore.cmp(
+                    utils.zeroBN,
+                ),
                 0,
             );
 
             assert.strictEqual(
-                totalSupplyBefore,
-                0,
-            );
-
-            assert.strictEqual(
-                allowanceBefore,
+                allowanceBefore.cmp(
+                    utils.zeroBN,
+                ),
                 0,
             );
 
@@ -146,30 +154,38 @@ contract('ValueBrandedToken::acceptStakeRequest', async () => {
                 { from: worker },
             );
 
-            const valueBrandedTokens = (await valueBrandedToken.convert.call(valueTokens)).toNumber();
-            const stakeRequestAfter = (await valueBrandedToken.stakeRequests(staker)).toNumber();
-            const balanceAfter = (await valueBrandedToken.balanceOf(staker)).toNumber();
-            const totalSupplyAfter = (await valueBrandedToken.totalSupply()).toNumber();
-            const allowanceAfter = (await valueBrandedToken.allowance(staker, gateway)).toNumber();
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
+            const stakeRequestAfter = await valueBrandedToken.stakeRequests.call(staker);
+            const balanceAfter = await valueBrandedToken.balanceOf.call(staker);
+            const totalSupplyAfter = await valueBrandedToken.totalSupply.call();
+            const allowanceAfter = await valueBrandedToken.allowance.call(staker, gateway);
 
             assert.strictEqual(
-                stakeRequestAfter,
+                stakeRequestAfter.cmp(
+                    utils.zeroBN,
+                ),
                 0,
             );
 
             assert.strictEqual(
-                balanceAfter,
-                (balanceBefore + valueBrandedTokens),
+                balanceAfter.cmp(
+                    (balanceBefore.add(valueBrandedTokens)),
+                ),
+                0,
             );
 
             assert.strictEqual(
-                totalSupplyAfter,
-                (totalSupplyBefore + valueBrandedTokens),
+                totalSupplyAfter.cmp(
+                    (totalSupplyBefore.add(valueBrandedTokens)),
+                ),
+                0,
             );
 
             assert.strictEqual(
-                allowanceAfter,
-                (allowanceBefore + valueBrandedTokens),
+                allowanceAfter.cmp(
+                    (allowanceBefore.add(valueBrandedTokens)),
+                ),
+                0,
             );
         });
     });

--- a/test/value_branded_token/accept_stake_request.js
+++ b/test/value_branded_token/accept_stake_request.js
@@ -1,0 +1,176 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+const BN = require('bn.js');
+const utils = require('../test_lib/utils.js');
+const { Event } = require('../test_lib/event_decoder');
+const { AccountProvider } = require('../test_lib/utils.js');
+const ValueBrandedTokenUtils = require('./utils.js');
+
+contract('ValueBrandedToken::acceptStakeRequest', async () => {
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Reverts if stake request is 0', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const nonStaker = accountProvider.get();
+            const worker = accountProvider.get();
+
+            await utils.expectRevert(
+                valueBrandedToken.acceptStakeRequest(
+                    nonStaker,
+                    { from: worker },
+                ),
+                'Should revert as stake request is zero.',
+                'Stake request is zero.',
+            );
+        });
+    });
+
+    contract('Events', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Emits StakeRequestAccepted, Transfer, and Approval events', async () => {
+            const {
+                valueBrandedToken,
+                valueTokens,
+                staker,
+            } = await ValueBrandedTokenUtils.createValueBrandedTokenAndStakeRequest(accountProvider);
+
+            const worker = accountProvider.get();
+
+            const transactionResponse = await valueBrandedToken.acceptStakeRequest(
+                staker,
+                { from: worker },
+            );
+
+            const gateway = await valueBrandedToken.gateway.call();
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
+
+            const events = Event.decodeTransactionResponse(
+                transactionResponse,
+            );
+
+            assert.strictEqual(
+                events.length,
+                3,
+            );
+
+            Event.assertEqual(events[0], {
+                name: 'StakeRequestAccepted',
+                args: {
+                    _staker: staker,
+                    _valueTokens: new BN(valueTokens),
+                },
+            });
+
+            Event.assertEqual(events[1], {
+                name: 'Transfer',
+                args: {
+                    _from: utils.NULL_ADDRESS,
+                    _to: staker,
+                    _value: valueBrandedTokens,
+                },
+            });
+
+            Event.assertEqual(events[2], {
+                name: 'Approval',
+                args: {
+                    _owner: staker,
+                    _spender: gateway,
+                    _value: valueBrandedTokens,
+                },
+            });
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+        const worker = accountProvider.get();
+
+        it('Successfully deletes the stake request, mints value branded tokens, and sets allowance for gateway', async () => {
+            const {
+                valueBrandedToken,
+                valueTokens,
+                staker,
+            } = await ValueBrandedTokenUtils.createValueBrandedTokenAndStakeRequest(accountProvider);
+
+            const gateway = await valueBrandedToken.gateway.call();
+            const stakeRequestBefore = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+            const balanceBefore = (await valueBrandedToken.balanceOf(staker)).toNumber();
+            const totalSupplyBefore = (await valueBrandedToken.totalSupply()).toNumber();
+            const allowanceBefore = (await valueBrandedToken.allowance(staker, gateway)).toNumber();
+
+            assert.isAbove(
+                stakeRequestBefore,
+                0,
+            );
+
+            assert.strictEqual(
+                balanceBefore,
+                0,
+            );
+
+            assert.strictEqual(
+                totalSupplyBefore,
+                0,
+            );
+
+            assert.strictEqual(
+                allowanceBefore,
+                0,
+            );
+
+            assert.isOk(
+                await valueBrandedToken.acceptStakeRequest.call(
+                    staker,
+                    { from: worker },
+                )
+            );
+
+            await valueBrandedToken.acceptStakeRequest(
+                staker,
+                { from: worker },
+            );
+
+            const valueBrandedTokens = (await valueBrandedToken.convert.call(valueTokens)).toNumber();
+            const stakeRequestAfter = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+            const balanceAfter = (await valueBrandedToken.balanceOf(staker)).toNumber();
+            const totalSupplyAfter = (await valueBrandedToken.totalSupply()).toNumber();
+            const allowanceAfter = (await valueBrandedToken.allowance(staker, gateway)).toNumber();
+
+            assert.strictEqual(
+                stakeRequestAfter,
+                0,
+            );
+
+            assert.strictEqual(
+                balanceAfter,
+                (balanceBefore + valueBrandedTokens),
+            );
+
+            assert.strictEqual(
+                totalSupplyAfter,
+                (totalSupplyBefore + valueBrandedTokens),
+            );
+
+            assert.strictEqual(
+                allowanceAfter,
+                (allowanceBefore + valueBrandedTokens),
+            );
+        });
+    });
+});

--- a/test/value_branded_token/constructor.js
+++ b/test/value_branded_token/constructor.js
@@ -22,15 +22,35 @@ contract('ValueBrandedToken::constructor', async () => {
     contract('Negative Tests', async (accounts) => {
         const accountProvider = new AccountProvider(accounts);
 
+        const conversionRateDecimals = 1;
+
         it('Reverts if valueToken is null', async () => {
             const valueToken = utils.NULL_ADDRESS;
+            const conversionRate = 35;
 
             await utils.expectRevert(
                 ValueBrandedToken.new(
                     valueToken,
+                    conversionRate,
+                    conversionRateDecimals,
                 ),
                 'Should revert as valueToken is null.',
                 'ValueToken is null.',
+            );
+        });
+
+        it('Reverts if conversionRate is zero', async () => {
+            const valueToken = accountProvider.get();
+            const conversionRate = 0;
+
+            await utils.expectRevert(
+                ValueBrandedToken.new(
+                    valueToken,
+                    conversionRate,
+                    conversionRateDecimals,
+                ),
+                'Should revert as conversionRate is zero.',
+                'ConversionRate is zero.',
             );
         });
     });
@@ -40,9 +60,13 @@ contract('ValueBrandedToken::constructor', async () => {
 
         it('Successfully sets the constructor arguments', async () => {
             const valueToken = accountProvider.get();
+            const conversionRate = 35;
+            const conversionRateDecimals = 1;
 
             const valueBrandedToken = await ValueBrandedToken.new(
                 valueToken,
+                conversionRate,
+                conversionRateDecimals,
             );
 
             assert.strictEqual(

--- a/test/value_branded_token/constructor.js
+++ b/test/value_branded_token/constructor.js
@@ -1,0 +1,54 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+const utils = require('../test_lib/utils.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+
+const ValueBrandedToken = artifacts.require('ValueBrandedToken');
+
+contract('ValueBrandedToken::constructor', async () => {
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Reverts if valueToken is null', async () => {
+            const valueToken = utils.NULL_ADDRESS;
+
+            await utils.expectRevert(
+                ValueBrandedToken.new(
+                    valueToken,
+                ),
+                'Should revert as valueToken is null.',
+                'ValueToken is null.',
+            );
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully sets the constructor arguments', async () => {
+            const valueToken = accountProvider.get();
+
+            const valueBrandedToken = await ValueBrandedToken.new(
+                valueToken,
+            );
+
+            assert.strictEqual(
+                (await valueBrandedToken.valueToken.call()),
+                valueToken,
+            );
+        });
+    });
+});

--- a/test/value_branded_token/convert.js
+++ b/test/value_branded_token/convert.js
@@ -1,0 +1,50 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+const BN = require('bn.js');
+const utils = require('../test_lib/utils.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+const ValueBrandedTokenUtils = require('./utils.js');
+
+contract('ValueBrandedToken::convert', async () => {
+    contract('Returns', async (accounts) => {
+        it('Returns correct conversions', async () => {
+            const accountProvider = new AccountProvider(accounts);
+
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueBrandedTokens0 = await valueBrandedToken.convert.call(utils.zeroBN);
+
+            assert.strictEqual(
+                valueBrandedTokens0.cmp(
+                    utils.zeroBN,
+                ),
+                0,
+            );
+
+            const conversionRate = await valueBrandedToken.conversionRate.call();
+            const conversionRateDecimals = await valueBrandedToken.conversionRateDecimals.call();
+            const valueTokens1 = new BN(1);
+            const valueBrandedTokens1 = await valueBrandedToken.convert.call(valueTokens1);
+
+            assert.strictEqual(
+                valueBrandedTokens1.cmp(
+                    valueTokens1.mul(conversionRate).div(new BN(10).pow(conversionRateDecimals)),
+                ),
+                0,
+            );
+        });
+    });
+});

--- a/test/value_branded_token/redeem.js
+++ b/test/value_branded_token/redeem.js
@@ -1,0 +1,196 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+const BN = require('bn.js');
+const utils = require('../test_lib/utils.js');
+const { Event } = require('../test_lib/event_decoder');
+const { AccountProvider } = require('../test_lib/utils.js');
+const ValueBrandedTokenUtils = require('./utils.js');
+
+const EIP20TokenMockPassFail = artifacts.require('EIP20TokenMockPassFail');
+const ValueBrandedToken = artifacts.require('ValueBrandedToken');
+
+contract('ValueBrandedToken::redeem', async () => {
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Reverts if balance is less than redeem amount', async () => {
+            const {
+                valueBrandedToken,
+                valueTokens,
+                staker,
+            } = await ValueBrandedTokenUtils.createValueBrandedTokenAndStakeRequest(accountProvider);
+
+            const valueBrandedTokens = 1;
+
+            await utils.expectRevert(
+                valueBrandedToken.redeem(
+                    valueBrandedTokens,
+                    { from: staker },
+                ),
+                'Should revert as staker has a balance less than redeem amount.',
+            );
+        });
+
+        it('Reverts if valueToken.transfer returns false', async () => {
+            const valueToken = await EIP20TokenMockPassFail.new();
+            const valueBrandedToken = await ValueBrandedToken.new(
+                valueToken.address,
+            );
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 0;
+            const gasLimit = 0;
+            const nonce = 0;
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+            const worker = accountProvider.get();
+
+            await valueBrandedToken.requestStake(
+                valueTokens,
+                valueBrandedTokens,
+                beneficiary,
+                gasPrice,
+                gasLimit,
+                nonce,
+                signature,
+                { from: staker },
+            );
+
+            await valueBrandedToken.acceptStakeRequest(
+                staker,
+                { from: worker },
+            );
+
+            await utils.expectRevert(
+                valueBrandedToken.redeem(
+                    valueBrandedTokens,
+                    { from: staker },
+                ),
+                'Should revert as valueToken.transfer returned false.',
+                'ValueToken.transfer returned false.',
+            );
+        });
+    });
+
+    contract('Events', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Emits Transfer event', async () => {
+            const {
+                valueBrandedToken,
+                valueTokens,
+                staker,
+            } = await ValueBrandedTokenUtils.createValueBrandedTokenAndStakeRequest(accountProvider);
+
+            const worker = accountProvider.get();
+
+            await valueBrandedToken.acceptStakeRequest(
+                staker,
+                { from: worker },
+            );
+
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
+
+            const transactionResponse = await valueBrandedToken.redeem(
+                valueBrandedTokens,
+                { from: staker },
+            );
+
+            const events = Event.decodeTransactionResponse(
+                transactionResponse,
+            );
+
+            assert.strictEqual(
+                events.length,
+                1,
+                'Only Transfer event should be emitted.',
+            );
+
+            Event.assertEqual(events[0], {
+                name: 'Transfer',
+                args: {
+                    _from: staker,
+                    _to: utils.NULL_ADDRESS,
+                    _value: valueBrandedTokens,
+                },
+            });
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully reduces supply and redeemer balance and calls valueToken.transfer', async () => {
+            const {
+                valueBrandedToken,
+                valueTokens,
+                staker,
+            } = await ValueBrandedTokenUtils.createValueBrandedTokenAndStakeRequest(accountProvider);
+
+            const worker = accountProvider.get();
+
+            await valueBrandedToken.acceptStakeRequest(
+                staker,
+                { from: worker },
+            );
+
+            const valueBrandedTokens = (await valueBrandedToken.convert.call(valueTokens)).toNumber();
+            const balanceBefore = (await valueBrandedToken.balanceOf(staker)).toNumber();
+            const totalSupplyBefore = (await valueBrandedToken.totalSupply()).toNumber();
+
+            assert.strictEqual(
+                totalSupplyBefore,
+                valueBrandedTokens,
+            );
+
+            assert.strictEqual(
+                balanceBefore,
+                valueBrandedTokens,
+            );
+
+            const result = await valueBrandedToken.redeem.call(
+                valueBrandedTokens,
+                { from: staker },
+            );
+
+            assert.strictEqual(
+                result.toNumber(),
+                valueTokens
+            );
+
+            await valueBrandedToken.redeem(
+                valueBrandedTokens,
+                { from: staker },
+            );
+
+            const totalSupplyAfter = (await valueBrandedToken.totalSupply()).toNumber();
+            const balanceAfter = (await valueBrandedToken.balanceOf(staker)).toNumber();
+
+            assert.strictEqual(
+                totalSupplyAfter,
+                (totalSupplyBefore - valueBrandedTokens),
+            );
+
+            assert.strictEqual(
+                balanceAfter,
+                (balanceBefore - valueBrandedTokens),
+            );
+        });
+    });
+});

--- a/test/value_branded_token/redeem.js
+++ b/test/value_branded_token/redeem.js
@@ -150,18 +150,22 @@ contract('ValueBrandedToken::redeem', async () => {
                 { from: worker },
             );
 
-            const valueBrandedTokens = (await valueBrandedToken.convert.call(valueTokens)).toNumber();
-            const balanceBefore = (await valueBrandedToken.balanceOf(staker)).toNumber();
-            const totalSupplyBefore = (await valueBrandedToken.totalSupply()).toNumber();
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
+            const totalSupplyBefore = await valueBrandedToken.totalSupply.call();
+            const balanceBefore = await valueBrandedToken.balanceOf.call(staker);
 
             assert.strictEqual(
-                totalSupplyBefore,
-                valueBrandedTokens,
+                totalSupplyBefore.cmp(
+                    valueBrandedTokens,
+                ),
+                0,
             );
 
             assert.strictEqual(
-                balanceBefore,
-                valueBrandedTokens,
+                balanceBefore.cmp(
+                    valueBrandedTokens,
+                ),
+                0,
             );
 
             const result = await valueBrandedToken.redeem.call(
@@ -170,8 +174,10 @@ contract('ValueBrandedToken::redeem', async () => {
             );
 
             assert.strictEqual(
-                result.toNumber(),
-                valueTokens
+                result.cmp(
+                    new BN(valueTokens)
+                ),
+                0,
             );
 
             await valueBrandedToken.redeem(
@@ -179,17 +185,21 @@ contract('ValueBrandedToken::redeem', async () => {
                 { from: staker },
             );
 
-            const totalSupplyAfter = (await valueBrandedToken.totalSupply()).toNumber();
-            const balanceAfter = (await valueBrandedToken.balanceOf(staker)).toNumber();
+            const totalSupplyAfter = await valueBrandedToken.totalSupply.call();
+            const balanceAfter = await valueBrandedToken.balanceOf.call(staker);
 
             assert.strictEqual(
-                totalSupplyAfter,
-                (totalSupplyBefore - valueBrandedTokens),
+                totalSupplyAfter.cmp(
+                    (totalSupplyBefore.sub(valueBrandedTokens)),
+                ),
+                0,
             );
 
             assert.strictEqual(
-                balanceAfter,
-                (balanceBefore - valueBrandedTokens),
+                balanceAfter.cmp(
+                    (balanceBefore.sub(valueBrandedTokens)),
+                ),
+                0,
             );
         });
     });

--- a/test/value_branded_token/redeem.js
+++ b/test/value_branded_token/redeem.js
@@ -46,8 +46,13 @@ contract('ValueBrandedToken::redeem', async () => {
 
         it('Reverts if valueToken.transfer returns false', async () => {
             const valueToken = await EIP20TokenMockPassFail.new();
+            const conversionRate = 35;
+            const conversionRateDecimals = 1;
+
             const valueBrandedToken = await ValueBrandedToken.new(
                 valueToken.address,
+                conversionRate,
+                conversionRateDecimals,
             );
 
             const valueTokens = 1;

--- a/test/value_branded_token/request_stake.js
+++ b/test/value_branded_token/request_stake.js
@@ -36,14 +36,15 @@ contract('ValueBrandedToken::requestStake', async () => {
             const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
 
             const valueTokens = 0;
-            const valueBrandedTokens = 0;
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
+            const beneficiary = accountProvider.get();
             const signature = '0x00';
 
             await utils.expectRevert(
                 valueBrandedToken.requestStake(
                     valueTokens,
                     valueBrandedTokens,
-                    valueTokens,
+                    beneficiary,
                     gasPrice,
                     gasLimit,
                     nonce,
@@ -59,7 +60,7 @@ contract('ValueBrandedToken::requestStake', async () => {
             const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
 
             const valueTokens = 1;
-            const valueBrandedTokens = 0;
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
             const beneficiary = utils.NULL_ADDRESS;
             const signature = '0x00';
 
@@ -83,7 +84,7 @@ contract('ValueBrandedToken::requestStake', async () => {
             const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
 
             const valueTokens = 1;
-            const valueBrandedTokens = 0;
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
             const beneficiary = accountProvider.get();
             const signature = '0x';
 
@@ -103,11 +104,35 @@ contract('ValueBrandedToken::requestStake', async () => {
             );
         });
 
-        it('Reverts if staker has a stake request', async () => {
+        it('Reverts if valueBrandedTokens is not equivalent to valueTokens', async () => {
             const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
 
             const valueTokens = 1;
             const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const signature = '0x00';
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as valueBrandedTokens is not equivalent to valueTokens.',
+                'ValueBrandedTokens is not equivalent to valueTokens.',
+            );
+        });
+
+        it('Reverts if staker has a stake request', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
             const beneficiary = accountProvider.get();
             const signature = '0x00';
 
@@ -152,7 +177,7 @@ contract('ValueBrandedToken::requestStake', async () => {
             );
 
             const valueTokens = 1;
-            const valueBrandedTokens = 0;
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
             const beneficiary = accountProvider.get();
             const signature = '0x00';
 
@@ -182,7 +207,7 @@ contract('ValueBrandedToken::requestStake', async () => {
             const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
 
             const valueTokens = 1;
-            const valueBrandedTokens = 0;
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
             const beneficiary = accountProvider.get();
             const gasPrice = 0;
             const gasLimit = 0;
@@ -216,7 +241,7 @@ contract('ValueBrandedToken::requestStake', async () => {
                 name: 'StakeRequested',
                 args: {
                     _valueTokens: new BN(valueTokens),
-                    _valueBrandedTokens: new BN(valueBrandedTokens),
+                    _valueBrandedTokens: valueBrandedTokens,
                     _beneficiary: beneficiary,
                     _staker: staker,
                     _gasPrice: new BN(gasPrice),
@@ -235,7 +260,7 @@ contract('ValueBrandedToken::requestStake', async () => {
             const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
 
             const valueTokens = 1;
-            const valueBrandedTokens = 0;
+            const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
             const beneficiary = accountProvider.get();
             const gasPrice = 0;
             const gasLimit = 0;

--- a/test/value_branded_token/request_stake.js
+++ b/test/value_branded_token/request_stake.js
@@ -142,8 +142,13 @@ contract('ValueBrandedToken::requestStake', async () => {
 
         it('Reverts if valueToken.transferFrom returns false', async () => {
             const valueToken = await EIP20TokenMockFail.new();
+            const conversionRate = 35;
+            const conversionRateDecimals = 1;
+
             const valueBrandedToken = await ValueBrandedToken.new(
                 valueToken.address,
+                conversionRate,
+                conversionRateDecimals,
             );
 
             const valueTokens = 1;

--- a/test/value_branded_token/request_stake.js
+++ b/test/value_branded_token/request_stake.js
@@ -239,10 +239,12 @@ contract('ValueBrandedToken::requestStake', async () => {
 
             const staker = accountProvider.get();
 
-            const amountBeforeRequest = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+            const amountBeforeRequest = await valueBrandedToken.stakeRequests.call(staker);
 
             assert.strictEqual(
-                amountBeforeRequest,
+                amountBeforeRequest.cmp(
+                    utils.zeroBN,
+                ),
                 0,
             );
 
@@ -257,16 +259,20 @@ contract('ValueBrandedToken::requestStake', async () => {
                 { from: staker },
             );
 
-            const amountAfterRequest = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+            const amountAfterRequest = await valueBrandedToken.stakeRequests.call(staker)
 
-            assert.notStrictEqual(
-                amountBeforeRequest,
-                amountAfterRequest,
+            assert.strictEqual(
+                amountBeforeRequest.cmp(
+                    amountAfterRequest,
+                ),
+                -1,
             );
 
             assert.strictEqual(
-                amountAfterRequest,
-                valueTokens,
+                amountAfterRequest.cmp(
+                    new BN(valueTokens),
+                ),
+                0,
             );
         });
     });

--- a/test/value_branded_token/request_stake.js
+++ b/test/value_branded_token/request_stake.js
@@ -1,0 +1,273 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+const BN = require('bn.js');
+const utils = require('../test_lib/utils.js');
+const { Event } = require('../test_lib/event_decoder');
+const { AccountProvider } = require('../test_lib/utils.js');
+const ValueBrandedTokenUtils = require('./utils.js');
+
+const EIP20TokenMockFail = artifacts.require('EIP20TokenMockFail');
+const ValueBrandedToken = artifacts.require('ValueBrandedToken');
+
+contract('ValueBrandedToken::requestStake', async () => {
+    contract('Negative Tests', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        const gasPrice = 0;
+        const gasLimit = 0;
+        const nonce = 0;
+
+        const staker = accountProvider.get();
+
+        it('Reverts if valueTokens is zero', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 0;
+            const valueBrandedTokens = 0;
+            const signature = '0x00';
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    valueTokens,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as valueTokens is zero.',
+                'ValueTokens is zero.',
+            );
+        });
+
+        it('Reverts if beneficiary is null', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = utils.NULL_ADDRESS;
+            const signature = '0x00';
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as beneficiary is null.',
+                'Beneficiary is null.',
+            );
+        });
+
+        it('Reverts if signature is empty', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const signature = '0x';
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as signature is empty.',
+                'Signature is empty.',
+            );
+        });
+
+        it('Reverts if staker has a stake request', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+
+            await valueBrandedToken.requestStake(
+                valueTokens,
+                valueBrandedTokens,
+                beneficiary,
+                gasPrice,
+                gasLimit,
+                nonce,
+                signature,
+                { from: staker },
+            );
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as staker has a stake request.',
+                'Staker has a stake request.',
+            );
+        });
+
+        it('Reverts if valueToken.transferFrom returns false', async () => {
+            const valueToken = await EIP20TokenMockFail.new();
+            const valueBrandedToken = await ValueBrandedToken.new(
+                valueToken.address,
+            );
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+
+            await utils.expectRevert(
+                valueBrandedToken.requestStake(
+                    valueTokens,
+                    valueBrandedTokens,
+                    beneficiary,
+                    gasPrice,
+                    gasLimit,
+                    nonce,
+                    signature,
+                    { from: staker },
+                ),
+                'Should revert as valueToken.transferFrom returned false.',
+                'ValueToken.transferFrom returned false.',
+            );
+        });
+    });
+
+    contract('Events', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Emits StakeRequested event', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 0;
+            const gasLimit = 0;
+            const nonce = 0;
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+
+            const transactionResponse = await valueBrandedToken.requestStake(
+                valueTokens,
+                valueBrandedTokens,
+                beneficiary,
+                gasPrice,
+                gasLimit,
+                nonce,
+                signature,
+                { from: staker },
+            );
+
+            const events = Event.decodeTransactionResponse(
+                transactionResponse,
+            );
+
+            assert.strictEqual(
+                events.length,
+                1,
+                'Only StakeRequested event should be emitted.',
+            );
+
+            Event.assertEqual(events[0], {
+                name: 'StakeRequested',
+                args: {
+                    _valueTokens: new BN(valueTokens),
+                    _valueBrandedTokens: new BN(valueBrandedTokens),
+                    _beneficiary: beneficiary,
+                    _staker: staker,
+                    _gasPrice: new BN(gasPrice),
+                    _gasLimit: new BN(gasLimit),
+                    _nonce: new BN(nonce),
+                    _signature: signature,
+                },
+            });
+        });
+    });
+
+    contract('Storage', async (accounts) => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Successfully stores stake request', async () => {
+            const valueBrandedToken = await ValueBrandedTokenUtils.createValueBrandedToken(accountProvider);
+
+            const valueTokens = 1;
+            const valueBrandedTokens = 0;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 0;
+            const gasLimit = 0;
+            const nonce = 0;
+            const signature = '0x00';
+
+            const staker = accountProvider.get();
+
+            const amountBeforeRequest = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+
+            assert.strictEqual(
+                amountBeforeRequest,
+                0,
+            );
+
+            await valueBrandedToken.requestStake(
+                valueTokens,
+                valueBrandedTokens,
+                beneficiary,
+                gasPrice,
+                gasLimit,
+                nonce,
+                signature,
+                { from: staker },
+            );
+
+            const amountAfterRequest = (await valueBrandedToken.stakeRequests(staker)).toNumber();
+
+            assert.notStrictEqual(
+                amountBeforeRequest,
+                amountAfterRequest,
+            );
+
+            assert.strictEqual(
+                amountAfterRequest,
+                valueTokens,
+            );
+        });
+    });
+});

--- a/test/value_branded_token/utils.js
+++ b/test/value_branded_token/utils.js
@@ -39,7 +39,7 @@ module.exports.createValueBrandedTokenAndStakeRequest = async (accountProvider) 
     const valueBrandedToken = await this.createValueBrandedToken();
 
     const valueTokens = 1;
-    const valueBrandedTokens = 0;
+    const valueBrandedTokens = await valueBrandedToken.convert.call(valueTokens);
     const beneficiary = accountProvider.get();
     const gasPrice = 0;
     const gasLimit = 0;

--- a/test/value_branded_token/utils.js
+++ b/test/value_branded_token/utils.js
@@ -1,0 +1,28 @@
+// Copyright 2018 OST.com Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const EIP20TokenMockPass = artifacts.require('EIP20TokenMockPass');
+const ValueBrandedToken = artifacts.require('ValueBrandedToken');
+
+/**
+ * Creates a value branded token.
+ */
+module.exports.createValueBrandedToken = async () => {
+    const valueToken = await EIP20TokenMockPass.new();
+    const valueBrandedToken = await ValueBrandedToken.new(
+        valueToken.address,
+    );
+
+    return valueBrandedToken;
+};

--- a/test/value_branded_token/utils.js
+++ b/test/value_branded_token/utils.js
@@ -20,8 +20,13 @@ const ValueBrandedToken = artifacts.require('ValueBrandedToken');
  */
 module.exports.createValueBrandedToken = async () => {
     const valueToken = await EIP20TokenMockPass.new();
+    const conversionRate = 35;
+    const conversionRateDecimals = 1;
+
     const valueBrandedToken = await ValueBrandedToken.new(
         valueToken.address,
+        conversionRate,
+        conversionRateDecimals,
     );
 
     return valueBrandedToken;

--- a/test/value_branded_token/utils.js
+++ b/test/value_branded_token/utils.js
@@ -26,3 +26,37 @@ module.exports.createValueBrandedToken = async () => {
 
     return valueBrandedToken;
 };
+
+/**
+ * Creates a value branded token and a stake request.
+ */
+module.exports.createValueBrandedTokenAndStakeRequest = async (accountProvider) => {
+    const valueBrandedToken = await this.createValueBrandedToken();
+
+    const valueTokens = 1;
+    const valueBrandedTokens = 0;
+    const beneficiary = accountProvider.get();
+    const gasPrice = 0;
+    const gasLimit = 0;
+    const nonce = 0;
+    const signature = '0x00';
+
+    const staker = accountProvider.get();
+
+    await valueBrandedToken.requestStake(
+        valueTokens,
+        valueBrandedTokens,
+        beneficiary,
+        gasPrice,
+        gasLimit,
+        nonce,
+        signature,
+        { from: staker },
+    );
+
+    return {
+        valueBrandedToken,
+        valueTokens,
+        staker,
+    };
+};


### PR DESCRIPTION
🚫 Not to be considered until after #33 is merged.

This PR:
- updates the constructor to take conversion rate information (resolves #22)
- completes the public function for converting from value tokens to value branded tokens (resolves #11)
- uses the conversion function to require equivalence between value tokens and value branded tokens in requestStake (resolves #13)
- transfers equivalent value tokens to redeemers in redeem (resolves #23)

✅ tested
✅ linted
✅ changelogged

Diff against branching point: https://github.com/jasonklein/openst-tokens/compare/jasonbanks/gh15/redeem...jasonklein:jasonbanks/gh22/conversion